### PR TITLE
fix: keep intentionally empty folders when restoring the arrangement

### DIFF
--- a/App/ItemArrangementStore.swift
+++ b/App/ItemArrangementStore.swift
@@ -119,7 +119,10 @@ final class ItemArrangementStore {
                     }
                     return app
                 }
-                guard resolvedApps.isEmpty == false else { continue }
+                // Keep folders that were persisted as intentionally empty: `createEmptyFolder`
+                // makes one and prompts for a name before any app is dropped into it.
+                // Only drop folders whose apps are gone from disk.
+                guard folderRecord.bundleIDs.isEmpty || resolvedApps.isEmpty == false else { continue }
                 let folder = FolderItem(id: folderRecord.id, name: folderRecord.name, apps: resolvedApps)
                 orderedItems.append(.folder(folder))
             }


### PR DESCRIPTION
Fixes #15.

`arrangedItems` could not tell two situations apart: a folder created empty on
purpose by `createEmptyFolder`, and a folder whose apps no longer exist on disk.
Both were dropped, so a newly created folder vanished from the item list before
the user finished naming it.

The fix keeps a folder when it was persisted with an empty `bundleIDs` list, and
still drops folders whose apps cannot be resolved:

```swift
guard folderRecord.bundleIDs.isEmpty || resolvedApps.isEmpty == false else { continue }
```

### Verification

The package has no test target, so I checked `ItemArrangementStore` directly with
a small harness compiled against `Models.swift` and a copy of the store with a
redirectable base directory. Input: an empty folder, a folder holding one
installed app, and a folder referencing an uninstalled bundle id.

- before: only the folder with the installed app survived;
- after: the empty folder keeps its name, the populated folder is unchanged, and
  the folder with the missing app is still dropped.

`swift build` passes.
